### PR TITLE
Code Snippet Context Menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "Jay Ahn, Kiran Pinnipati",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "schema/*.json"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -43,7 +44,6 @@
     "@jupyterlab/application": "^2.1.2",
     "@jupyterlab/apputils": "^2.2.4",
     "@jupyterlab/cells": "^2.2.4",
-    "@jupyterlab/coreutils": "^4.1.0",
     "@jupyterlab/docmanager": "^2.1.2",
     "@jupyterlab/docregistry": "^2.1.2",
     "@jupyterlab/fileeditor": "^2.1.2",
@@ -77,7 +77,8 @@
     "style/*.css"
   ],
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "schemaDir": "schema"
   },
   "husky": {
     "hooks": {

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -2,8 +2,13 @@
   "jupyter.lab.shortcuts": [
     {
       "command": "codeSnippet:save-as-snippet",
-      "keys": ["Accel Shift S"],
+      "keys": ["Accel Shift A"],
       "selector": ".jp-Cell"
+    },
+    {
+      "command": "codeSnippet:save-as-snippet",
+      "keys": ["Accel Shift A"],
+      "selector": ".jp-FileEditor"
     }
   ],
   "type": "object"

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -1,0 +1,10 @@
+{
+  "jupyter.lab.shortcuts": [
+    {
+      "command": "codeSnippet:save-as-snippet",
+      "keys": ["Accel Shift S"],
+      "selector": ".jp-Cell"
+    }
+  ],
+  "type": "object"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import {
   ILayoutRestorer
 } from '@jupyterlab/application';
 import { ICommandPalette, WidgetTracker } from '@jupyterlab/apputils';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
 import { IEditorServices } from '@jupyterlab/codeeditor';
 import { LabIcon } from '@jupyterlab/ui-components';
 
@@ -23,6 +25,7 @@ import {
 
 const CODE_SNIPPET_EXTENSION_ID = 'code-snippet-extension';
 
+const CODE_SNIPPET_SETTING_ID = 'jupyterlab-code-snippets:settings';
 /**
  * Snippet Editor Icon
  */
@@ -150,7 +153,7 @@ function activateCodeSnippet(
   });
 
   //Add an application command
-  const saveCommand = 'save as code snippet';
+  const saveCommand = 'codeSnippet:save-as-snippet';
   const toggled = false;
   app.commands.addCommand(saveCommand, {
     label: 'Save As Code Snippet',
@@ -181,14 +184,6 @@ function activateCodeSnippet(
     selector: '.jp-FileEditor'
   });
 
-  // Add keybinding to save
-  app.commands.addKeyBinding({
-    command: saveCommand,
-    args: {},
-    keys: ['Accel Shift S'],
-    selector: '.jp-Cell'
-  });
-
   // Track and restore the widget state
   const tracker = new WidgetTracker<CodeSnippetEditor>({
     namespace: 'codeSnippetEditor'
@@ -217,6 +212,18 @@ function activateCodeSnippet(
   });
 }
 
+const codeSnippetExtensionSetting: JupyterFrontEndPlugin<void> = {
+  id: CODE_SNIPPET_SETTING_ID,
+  autoStart: true,
+  requires: [ISettingRegistry],
+  activate: (app: JupyterFrontEnd, settingRegistry: ISettingRegistry) => {
+    void settingRegistry
+      .load(CODE_SNIPPET_SETTING_ID)
+      .then(_ => console.log('settingRegistry successfully loaded!'))
+      .catch(e => console.log(e));
+  }
+};
+
 function getSelectedText(): string {
   let selectedText;
   // window.getSelection
@@ -230,4 +237,4 @@ function getSelectedText(): string {
   return selectedText.toString();
 }
 
-export default code_snippet_extension;
+export default [code_snippet_extension, codeSnippetExtensionSetting];

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,10 +169,16 @@ function activateCodeSnippet(
     }
   });
 
-  //Put the command above in context menu
+  // Put the saveCommand above in context menu
   app.contextMenu.addItem({
     command: saveCommand,
     selector: '.jp-Cell'
+  });
+
+  // Put the saveCommand in non-notebook file context menu
+  app.contextMenu.addItem({
+    command: saveCommand,
+    selector: '.jp-FileEditor'
   });
 
   // Add keybinding to save


### PR DESCRIPTION
- [x] Implement saving as code snippet command on a non-notebook file in #107 
* On a plain text file
![Screen Shot 2020-09-23 at 12 54 03 PM](https://user-images.githubusercontent.com/15991814/94063054-6afe5600-fd9c-11ea-9e6d-02dc02d5479f.png)
* On a python file
![Screen Shot 2020-09-23 at 12 55 00 PM](https://user-images.githubusercontent.com/15991814/94063061-6c2f8300-fd9c-11ea-8b44-8efdbaef6d9b.png)
- [x] Make save as code snippet shortcut user configurable #126 
![Screen Shot 2020-09-24 at 12 04 47 PM](https://user-images.githubusercontent.com/15991814/94191587-93508800-fe62-11ea-8bbf-7e8f29230d20.png)
  * See #133 
  * Need to add the same shortcut to fileEditor
- [ ] Add saving a cell as code snippet command to context menu #107 

