### PR TITLE
Fix right-click to save cell(s) error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,13 @@ import setuptools
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 # The name of the project
+
 name="code_snippet"
 
 # Get our version
 with open(os.path.join(HERE, 'package.json')) as f:
     version = json.load(f)['version']
+
 
 lab_path = os.path.join(HERE, name, "labextension")
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ function activateCodeSnippet(
         //if user just right-clicks cell(s) to save
         const curr = document.getElementsByClassName('jp-Cell jp-mod-selected');
         const resultArray = [];
-        for (let i = 1; i < curr.length; i++) {
+        for (let i = 0; i < curr.length; i++) {
           //loop through each cell
           const text = curr[i] as HTMLElement;
           const textContent = text.innerText;

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,6 +184,7 @@ function activateCodeSnippet(
         //if user just right-clicks cell(s) to save
         const curr = document.getElementsByClassName('jp-Cell jp-mod-selected');
         const resultArray = [];
+        // changed i = 1 to i = 0.
         for (let i = 0; i < curr.length; i++) {
           //loop through each cell
           const text = curr[i] as HTMLElement;


### PR DESCRIPTION
Fixed and tested issue with cell-saving on right click and with shortcut.

Tested: 
- Single cell save with right-click context menu
- Multi-cell save with right-click context menu
- Single cell save with keyboard shortcut
- Multi-cell save with keyboard shortcut

Change:
- src/index.ts : outer loop in save command modified from starting at 1 to starting at 0.