### PR TITLE
Fix New Snippet Editor Error

### DIFF
--- a/src/CodeSnippetContentsService.ts
+++ b/src/CodeSnippetContentsService.ts
@@ -50,6 +50,7 @@ export class CodeSnippetContentsService {
       });
       return data;
     } catch (error) {
+      console.log(error);
       throw error;
     }
     // const data = await this.contentsManager.get(path, {

--- a/src/CodeSnippetContentsService.ts
+++ b/src/CodeSnippetContentsService.ts
@@ -50,7 +50,7 @@ export class CodeSnippetContentsService {
       });
       return data;
     } catch (error) {
-      return error;
+      throw error;
     }
     // const data = await this.contentsManager.get(path, {
     //   type: type,


### PR DESCRIPTION
New snippet editor was erring upon creation of a new snippet and displaying a message indicating a snippet already existed even when it did not exist in the folder.