### PR TITLE
Make border of snippet consistent as JupyterLab system

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -71,7 +71,7 @@
 }
 
 .jp-codeSnippet-item {
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
   display: flex;
   margin: 0;
   padding: 0;
@@ -401,7 +401,7 @@
 }
 
 .jp-codeSnippet-filterTools {
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
 }
 
 mark.jp-codeSnippet-search-bolding {
@@ -435,7 +435,7 @@ mark.jp-codeSnippet-search-bolding {
 .jp-codeSnippet-filter-arrow-up {
   position: absolute;
   margin-top: 20px;
-  border: var(--jp-border-width) solid var(--jp-border-color1);
+  border: var(--jp-border-width) solid var(--jp-border-color2);
   border-width: 0 var(--jp-border-width) var(--jp-border-width) 0;
   padding: 4px;
   margin-right: 38px;
@@ -446,7 +446,7 @@ mark.jp-codeSnippet-search-bolding {
 }
 
 .jp-codeSnippet-filter-option {
-  border: var(--jp-border-width) solid var(--jp-border-color1);
+  border: var(--jp-border-width) solid var(--jp-border-color2);
   height: 140px;
   width: 100%;
   margin-bottom: 10px;
@@ -481,7 +481,7 @@ mark.jp-codeSnippet-search-bolding {
 }
 
 .jp-codeSnippet-tools {
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
 }
 
 /* Code Snippet Tags in InputDialog */


### PR DESCRIPTION
Made the border line a little lighter than before.
<img width="285" alt="Screen Shot 2021-04-12 at 12 06 47 PM" src="https://user-images.githubusercontent.com/15991814/114447986-dc122900-9b87-11eb-9883-425b3bc88eda.png">
<img width="298" alt="Screen Shot 2021-04-12 at 12 08 26 PM" src="https://user-images.githubusercontent.com/15991814/114447976-d9afcf00-9b87-11eb-9c15-ecf36c4c863b.png">

