### PR TITLE
Rename downloadSnippet to exportSnippet

### DIFF
--- a/src/CodeSnippetDisplay.tsx
+++ b/src/CodeSnippetDisplay.tsx
@@ -118,8 +118,7 @@ const CODE_SNIPPET_MORE_OTPIONS_COPY = 'jp-codeSnippet-more-options-copy';
 const CODE_SNIPPET_MORE_OTPIONS_INSERT = 'jp-codeSnippet-more-options-insert';
 const CODE_SNIPPET_MORE_OTPIONS_EDIT = 'jp-codeSnippet-more-options-edit';
 const CODE_SNIPPET_MORE_OTPIONS_DELETE = 'jp-codeSnippet-more-options-delete';
-const CODE_SNIPPET_MORE_OTPIONS_DOWNLOAD =
-  'jp-codeSnippet-more-options-download';
+const CODE_SNIPPET_MORE_OTPIONS_EXPORT = 'jp-codeSnippet-more-options-export';
 const CODE_SNIPPET_CREATE_NEW_BTN = 'jp-createSnippetBtn';
 const CODE_SNIPPET_NAME = 'jp-codeSnippet-name';
 const OPTIONS_BODY = 'jp-codeSnippet-options-body';
@@ -1488,35 +1487,37 @@ export class CodeSnippetDisplay extends React.Component<
     });
   }
 
-  private downloadCommand(codeSnippet: ICodeSnippet): void {
+  private exportCommand(codeSnippet: ICodeSnippet): void {
     // Request a text
     InputDialog.getText({
-      title: 'Download Snippet?',
-      label: 'Directory to Download: ',
+      title: 'Export Snippet?',
+      label: 'Directory to Export: ',
       placeholder: 'share/snippet',
-      okLabel: 'Download',
+      okLabel: 'Export',
     }).then((value: Dialog.IResult<string>) => {
       if (value.button.accept) {
         const dirs = value.value.split('/');
 
-        const codeSnippetDownloader = CodeSnippetContentsService.getInstance();
+        const codeSnippetContentsManager = CodeSnippetContentsService.getInstance();
 
         let path = '';
         for (let i = 0; i < dirs.length; i++) {
           path += dirs[i] + '/';
-          codeSnippetDownloader.save(path, { type: 'directory' }).catch((_) => {
-            alert('Path should be a relative path');
-          });
+          codeSnippetContentsManager
+            .save(path, { type: 'directory' })
+            .catch((_) => {
+              alert('Path should be a relative path');
+            });
         }
 
         path += codeSnippet.name + '.json';
 
-        codeSnippetDownloader.save(path, {
+        codeSnippetContentsManager.save(path, {
           type: 'file',
           format: 'text',
           content: JSON.stringify(codeSnippet),
         });
-        showMessage('download');
+        showMessage('export');
       }
     });
   }
@@ -1578,18 +1579,18 @@ export class CodeSnippetDisplay extends React.Component<
       this.removeOptionsNode();
     };
 
-    const downloadSnip = document.createElement('div');
-    downloadSnip.className = CODE_SNIPPET_MORE_OTPIONS_DOWNLOAD;
-    downloadSnip.textContent = 'Download snippet';
-    downloadSnip.onclick = (): void => {
-      this.downloadCommand(codeSnippet);
+    const exportSnip = document.createElement('div');
+    exportSnip.className = CODE_SNIPPET_MORE_OTPIONS_EXPORT;
+    exportSnip.textContent = 'Export snippet';
+    exportSnip.onclick = (): void => {
+      this.exportCommand(codeSnippet);
       this.removeOptionsNode();
     };
 
     optionsContainer.appendChild(insertSnip);
     optionsContainer.appendChild(copySnip);
     optionsContainer.appendChild(editSnip);
-    optionsContainer.appendChild(downloadSnip);
+    optionsContainer.appendChild(exportSnip);
     optionsContainer.appendChild(deleteSnip);
     body.append(optionsContainer);
     return body;

--- a/src/CodeSnippetMessage.ts
+++ b/src/CodeSnippetMessage.ts
@@ -103,8 +103,8 @@ namespace Private {
       message.textContent = 'Saved as Snippet!';
     } else if (type === 'copy') {
       message.textContent = 'Saved to Clipboard!';
-    } else if (type === 'download') {
-      message.textContent = 'Downloaded the Snippet!';
+    } else if (type === 'export') {
+      message.textContent = 'Exported the Snippet!';
     }
     messageContainer.appendChild(message);
     body.append(messageContainer);

--- a/style/base.css
+++ b/style/base.css
@@ -677,13 +677,13 @@ mark.jp-codeSnippet-search-bolding {
   cursor: pointer;
 }
 
-.jp-codeSnippet-more-options-download {
+.jp-codeSnippet-more-options-export {
   color: var(--jp-brand-color0);
   padding-bottom: 5px;
   cursor: pointer;
 }
 
-.jp-codeSnippet-more-options-download:hover {
+.jp-codeSnippet-more-options-export:hover {
   background-color: var(--jp-layout-color2);
   cursor: pointer;
 }


### PR DESCRIPTION
Per our meeting on last Friday, changed the downloadSnippet to exportSnippet as it's more appropriate.
* The idea is that it should be exported to the JupyterLab filesystem and downloaded through the filebrowser.
* A few UI changes below:
  <img width="180" alt="Screen Shot 2021-06-03 at 12 03 57 PM" src="https://user-images.githubusercontent.com/15991814/120698485-fcfa4a80-c463-11eb-9e03-c7b7d0fc89f6.png">
  <img width="298" alt="Screen Shot 2021-06-03 at 12 04 36 PM" src="https://user-images.githubusercontent.com/15991814/120698484-fc61b400-c463-11eb-9ef5-1a280edd625a.png">
  <img width="247" alt="Screen Shot 2021-06-03 at 12 04 57 PM" src="https://user-images.githubusercontent.com/15991814/120698482-fbc91d80-c463-11eb-88bd-614b87dd1837.png">


