### PR TITLE
Allow globally defined snippets in overrides.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@jupyterlab/apputils": "^3.5.2",
     "@jupyterlab/cells": "^3.5.0",
     "@jupyterlab/celltags": "^3.5.2",
-    "@jupyterlab/coreutils": "5.5.2",
+    "@jupyterlab/coreutils": "^5.5.2",
     "@jupyterlab/docmanager": "^3.5.2",
     "@jupyterlab/docregistry": "^3.5.0",
     "@jupyterlab/fileeditor": "^3.5.2",

--- a/src/CodeSnippetService.ts
+++ b/src/CodeSnippetService.ts
@@ -61,12 +61,19 @@ export class CodeSnippetService {
     });
 
     // load user's saved snippets
+    let userSnippets = new Array();
     if (this.settingManager.get('snippets').user) {
-      const userSnippets = this.convertToICodeSnippetList(
+      userSnippets = userSnippets.concat(this.convertToICodeSnippetList(
         this.settingManager.get('snippets').user as JSONArray
-      );
-      this.codeSnippetList = userSnippets;
+      ));
     }
+    // load global snippets 
+    if (this.settingManager.get('snippets').composite) {
+      userSnippets = userSnippets.concat(this.convertToICodeSnippetList(
+        this.settingManager.get('snippets').composite as JSONArray
+      ));
+    }
+    this.codeSnippetList = userSnippets;
 
     // set default preview font size
     if (this.settingManager.get('snippetPreviewFontSize').user === undefined) {


### PR DESCRIPTION
Currently if we want to provide JupyterLab's users globally defined snippets by setting them inside `<sys.prefix>/local/share/jupyter/lab/settings/overrides.json` ([see JupyterLab's documentation](https://jupyterlab.readthedocs.io/en/stable/user/directories.html#overridesjson)), these are ignored until manually set inside `~/.jupyter/lab/user-settings/jupyterlab-code-snippets/snippets.jupyterlab-settings` via the widget or the settings GUI.

The goal of this commit is to allow snippets initialization through extension overridden settings without user interaction at Lab startup.

Dummy `overrides.json` example:
```json
{
    "jupyterlab-code-snippets:snippets": {
        "snippets": [
            {
                "id": 1,
                "tags": [],
                "name": "Hello World",
                "language": "Python",
                "code": "print('Hello, World!')"
            }
        ]
    }
}
```